### PR TITLE
Fix asset file name

### DIFF
--- a/packages/kubrick/vite.config.ts
+++ b/packages/kubrick/vite.config.ts
@@ -43,7 +43,7 @@ export default defineConfig({
 						return '_PreviewProvider.css';
 					}
 
-					return `${name}.[ext]`;
+					return `${name}`;
 				},
 				entryFileNames: '[name].js',
 			},


### PR DESCRIPTION
Remove the additional `.css` output in the file name e.g. `File.css.css` to `File.css`