### PR TITLE
Remove element when label is not provided

### DIFF
--- a/packages/kubrick/src/CheckboxGroup/CheckboxGroup.tsx
+++ b/packages/kubrick/src/CheckboxGroup/CheckboxGroup.tsx
@@ -84,25 +84,27 @@ export const CheckboxGroup = forwardRef<HTMLDivElement, CheckboxGroupProps>(
 				aria-invalid={isInvalid}
 				ref={ref}
 			>
-				<span
-					{...labelProps}
-					className={clsx({
-						classNames: classes.label,
-						prefixedNames: 'label',
-					})}
-				>
-					{label}
-					{isRequired ?
-						<span
-							className={clsx({
-								classNames: classes.markedRequired,
-								prefixedNames: 'marked-required',
-							})}
-						>
-							*
-						</span>
-					:	''}
-				</span>
+				{label && (
+					<span
+						{...labelProps}
+						className={clsx({
+							classNames: classes.label,
+							prefixedNames: 'label',
+						})}
+					>
+						{label}
+						{isRequired ?
+							<span
+								className={clsx({
+									classNames: classes.markedRequired,
+									prefixedNames: 'marked-required',
+								})}
+							>
+								*
+							</span>
+						:	''}
+					</span>
+				)}
 				<CheckboxGroupContext.Provider value={state}>
 					<div
 						className={clsx({


### PR DESCRIPTION
This Pull Request adds new logic in the `CheckboxGroup` component that handles the element for the label. If the label is not provided, it now will  not render the element in the DOM.